### PR TITLE
Throw an exception if HTTP status is not 2XX

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -63,6 +63,9 @@ class Fluent::SumologicOutput< Fluent::BufferedOutput
 
     request = Net::HTTP::Post.new(@path)
     request.body = messages.join("\n")
-    http.request(request)
+    response = http.request(request)
+    unless response.is_a?(Net::HTTPSuccess)
+      raise "Failed to send data to #{@host}. #{response.code} #{response.message}"
+    end 
   end
 end


### PR DESCRIPTION
We would lost log messages silently. 
See https://sumologic.zendesk.com/entries/62972608-HTTP-source-API-documentation 