### PR TITLE
ruby 1.9.3 Net::HTTP requires you to use the Proxy subclass 

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -57,7 +57,8 @@ class Fluent::SumologicOutput< Fluent::BufferedOutput
         end
     end
 
-    http = Net::HTTP.new(@host, @port.to_i)
+    (proxy,proxy_port) = ENV['http_proxy'].split(':')
+    http = Net::HTTP::Proxy(proxy,proxy_port).new(@host, @port.to_i)
     http.use_ssl = true
     http.verify_mode = @verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
     http.set_debug_output $stderr


### PR DESCRIPTION
This is a forwards compatible change which allows older rubies to use a proxy specified in the environment.