### PR TITLE
Allow proxy to be set in match config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Or install it yourself as:
 	  type sumologic
       host collectors.sumologic.com
       port 443
+      proxy 10.0.0.1:3128
       format json|text
       path /receiver/v1/http/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX==
 	</match>
@@ -42,6 +43,9 @@ Or install it yourself as:
 
 #### port
 - Port of HTTP Collectors URL
+
+#### proxy
+- HTTP proxy address including port
 
 #### path
 - Path of HTTP Collectors URL

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -64,9 +64,12 @@ class Fluent::SumologicOutput< Fluent::BufferedOutput
         end
     end
 
+    http = Net::HTTP.new(@host, @port.to_i)
     proxy_string = if ENV['http_proxy'] then ENV['http_proxy'] else @proxy end
-    (proxy,proxy_port) = proxy_string.split(':')
-    http = Net::HTTP::Proxy(proxy,proxy_port).new(@host, @port.to_i)
+    if(proxy_string){
+        (proxy,proxy_port) = proxy_string.split(':')
+        http = Net::HTTP::Proxy(proxy,proxy_port).new(@host, @port.to_i)
+    }
     http.use_ssl = true
     http.verify_mode = @verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
     http.set_debug_output $stderr

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -7,6 +7,7 @@ class Fluent::SumologicOutput< Fluent::BufferedOutput
 
   config_param :host, :string,  :default => 'collectors.sumologic.com'
   config_param :port, :integer, :default => 443
+  config_param :proxy, :string, :default => nil
   config_param :verify_ssl, :bool, :default => true
   config_param :path, :string,  :default => '/receiver/v1/http/XXX'
   config_param :format, :string, :default => 'json'
@@ -63,7 +64,8 @@ class Fluent::SumologicOutput< Fluent::BufferedOutput
         end
     end
 
-    (proxy,proxy_port) = ENV['http_proxy'].split(':')
+    proxy_string = if ENV['http_proxy'] then ENV['http_proxy'] else @proxy end
+    (proxy,proxy_port) = proxy_string.split(':')
     http = Net::HTTP::Proxy(proxy,proxy_port).new(@host, @port.to_i)
     http.use_ssl = true
     http.verify_mode = @verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
In some environments it is difficult to consistently set the environment of fluentd. This patch lets the user specify a proxy address in the match configuration along with the sumologic endpoint information.
